### PR TITLE
Minor plotting bug and uniform settings for all examples

### DIFF
--- a/Simulation.m
+++ b/Simulation.m
@@ -279,12 +279,12 @@ classdef Simulation
             %dimension by default)
             %
             figure(1); clf;
-            energy = state.diff_energy(1:state.it);
-            threshold = obj.energy_threshold * state.source_energy;
+            energy = state.diff_energy(1:state.it) / state.diff_energy(1);
+            % threshold = obj.energy_threshold;% * state.source_energy;
             %E = state.E;
             E = state.dE;
             E = max(max(E, [], 1), [], 1);
-            subplot(2,1,1); plot(1:length(energy),log10(energy),'b',[1,length(energy)],log10(threshold)*ones(1,2),'--r');
+            subplot(2,1,1); plot(1:length(energy),log10(energy),'b',[1,length(energy)],log10(obj.energy_threshold)*ones(1,2),'--r');
             title(length(energy));  xlabel('# iterations'); ylabel('log_{10}(energy added)');
             
             % plot midline along longest dimension

--- a/examples/disordered_medium_2D.m
+++ b/examples/disordered_medium_2D.m
@@ -1,7 +1,7 @@
 %%% Simulates the wave propagation of a point source in a 2D random medium
 %%% Gerwin Osnabrugge 2015
 
-clear all;close all;
+clear; close all;
 addpath('..');
 
 %% simulation options
@@ -10,7 +10,7 @@ opt.lambda = 1;                  % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-10;    % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW; % grid pixel size (in um)
 opt.boundary_widths = [0,0];     % periodic boundaries
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/disordered_medium_3D.m
+++ b/examples/disordered_medium_3D.m
@@ -1,7 +1,7 @@
 %%% Simulates the wave propagation of a point source in a 3D random medium
 %%% Gerwin Osnabrugge 2015
 
-clear all; close all; clear mex; 
+clear; close all;
 addpath('..');
 
 %% simulation options
@@ -10,7 +10,7 @@ opt.lambda = 1;                  % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-8;     % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW; % grid pixel size (in um)
 opt.boundary_widths = [0,0,0];   % periodic boundaries
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/homogeneous_medium_2D.m
+++ b/examples/homogeneous_medium_2D.m
@@ -1,7 +1,7 @@
 %%% Simulates the wave propagation of a point source in a 2D homogeneous medium
 %%% Gerwin Osnabrugge 2015
 
-clear all; close all;
+clear; close all;
 addpath('..');
 
 %% simulation options
@@ -10,7 +10,7 @@ opt.lambda = 1;                  % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-10;    % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW; % grid pixel size (in um)
 opt.boundary_widths = PPW*[2,2]; % absorbing boundaries
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/medium_interface_2D.m
+++ b/examples/medium_interface_2D.m
@@ -1,14 +1,16 @@
 %%% example script simulating a plane wave through an interface of two
 %%% media with different refractive indices
+
+clear; close all;
 addpath('..');
-clear
+
 %% simulation options
 PPW=8;                           % points per wavelength
 opt.lambda = 1;                  % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-4;     % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW; % grid pixel size (in um)
 opt.boundary_widths = PPW*[2,2]; % absorbing boundaries
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/medium_interface_3D.m
+++ b/examples/medium_interface_3D.m
@@ -1,15 +1,17 @@
 %%% example script simulating a plane wave through an interface of two
 %%% media with different refractive indices, changed to work in 3D. 
 %%% Run this on a (fast) nVidia GPU or face the consequences.
+
+clear; close all;
 addpath('..');
-clear
+
 %% simulation options
 PPW=8;                              % points per wavelength
 opt.lambda = 1;                     % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-4;        % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW;    % grid pixel size (in um)
 opt.boundary_widths = PPW*[2,2,2];  % absorbing boundaries
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/medium_interface_oversampling.m
+++ b/examples/medium_interface_oversampling.m
@@ -1,15 +1,16 @@
 %%% example script simulating a plane wave through an interface of two
 %%% media with different refractive indices
+
+clear; close all;
 addpath('..');
 
-clear; clear mex; 
 %% simulation options
 PPW=8;                           % points per wavelength
 opt.lambda = 1;                  % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-4;     % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW; % grid pixel size (in um)
 opt.boundary_widths = PPW*[2,0]; % absorbing boundaries
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/phase_conjugation.m
+++ b/examples/phase_conjugation.m
@@ -5,7 +5,7 @@
 % --> forms sharp focus again
 %%% Gerwin Osnabrugge 2015
 
-clear all; close all;
+clear; close all;
 addpath('..');
 
 %% simulations options
@@ -13,8 +13,8 @@ PPW=4;                                    % points per wavelength
 opt.lambda = 1;                           % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-12;             % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW;          % grid pixel size (in um)
-opt.boundary_widths = [4*PPW,4*PPW];      % absorbing boundaries
-opt.usemex = false;
+opt.boundary_widths = PPW*[4,4];      % absorbing boundaries
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end

--- a/examples/pulse2d.m
+++ b/examples/pulse2d.m
@@ -1,7 +1,7 @@
 %%% Simulate the pulse propagation of a plane wave with a specified bandwidth 
 %%% in a 2D disordered medium
 
-clear all; close all;
+clear; close all;
 addpath('..');
 
 %% simulations options
@@ -10,7 +10,7 @@ opt.lambda = 1;                   % wavelength in vacuum (in um)
 opt.energy_threshold = 1E-10;     % simulation has converged when total added energy is lower than threshold 
 opt.pixel_size = opt.lambda/PPW;  % grid pixel size (in um)
 opt.boundary_widths = [0,4*PPW];  % periodic boundary in y, absorbing boundary in x
-opt.usemex = false;
+opt.usemex = true;
 if(opt.usemex)
     addpath('..\MexBin');
 end


### PR DESCRIPTION
1. Normalization of `diff_energy` and `energy_threshold` in plotting corrected
2. `clear; close all;` and `opt.use_mex=true;` in all examples